### PR TITLE
Disable reading config

### DIFF
--- a/src/Kix/MdashBundle/DependencyInjection/KixMdashExtension.php
+++ b/src/Kix/MdashBundle/DependencyInjection/KixMdashExtension.php
@@ -19,9 +19,6 @@ class KixMdashExtension extends Extension
      */
     public function load(array $configs, ContainerBuilder $container)
     {
-        $configuration = new Configuration();
-        $this->processConfiguration($configuration, $configs);
-
         $loader = new Loader\YamlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
         $loader->load('services.yml');
     }


### PR DESCRIPTION
Bundle has not extra configuration and TreeBuilder has not declared configuration tree. So on cache clearing it's throws RuntimeException: The configuration tree has no root node.
